### PR TITLE
Update README.md to allow copy/paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Create a lambda layer that contains `requests` and `pyyaml`.
 mkdir layer && cd $_
 pip install requests pyyaml -t python/
 zip -r ../layer.zip python
+cd ..
 ```
 
 Download the fix/static files from NOAA. Note, this will take awhile as it


### PR DESCRIPTION
Currently, you cannot copy/paste the README code blocks to deploy the project in your account b/c the directions for creating a lambda layer leave you in the wrong directory.
